### PR TITLE
Bump the synver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = '>=3.11'
 license = { text = 'Apache License 2.0' }
 dependencies = [
     'pygls==1.3.1',
-    'synapse==2.183.0',
+    'synapse>=2.198.0,<3.0.0',
     'lsprotocol==2023.0.1'
 ]
 authors = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pygls>=1.3.1,<2.0.0
-synapse==2.183.0
+synapse>=2.198.0,<3.0.0
 lsprotocol==2023.0.1

--- a/stormgls/stormgls.py
+++ b/stormgls/stormgls.py
@@ -455,9 +455,6 @@ async def semantic_tokens(ls: StormLanguageServer, params: types.SemanticTokensP
         elif info := ls.completions['props'].get(txt):
             if info.get('deprecated', False) is True:
                 flags |= 1
-        else:
-            if type != 8:
-                flags = 1
 
         valu = [
             line - prevLine,


### PR DESCRIPTION
Forgot that the `<refs)+ $srcnode` was added in synapse v2.198.0, but we still had v2.183.0 pinned due to my own laziness while on a train.

Also cleans up a small misleading false deprecation warning from the semantic tokens stuff.